### PR TITLE
Improve documentation section layout

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -23,16 +23,56 @@
 
 ## 📚 Documentation
 
-| Guide | Description |
-|-------|-------------|
-| [🚀 Quick Start](#quick-start) | Get up and running in minutes |
-| [📖 API Documentation](docs/api.md) | Complete API reference with examples |
-| [🏗️ Architecture](docs/architecture.md) | Technical architecture and design patterns |
-| [🚀 Deployment](docs/deployment.md) | Production deployment guides |
-| [💻 Development](docs/development.md) | Development setup and workflows |
-| [🔧 Troubleshooting](docs/troubleshooting.md) | Common issues and solutions |
-| [🤝 Contributing](docs/contributing.md) | How to contribute to the project |
-| [📋 Changelog](docs/changelog.md) | Version history and changes |
+<div align="center">
+
+<table>
+  <tr>
+    <td>
+      <h3>🚀 Quick Start</h3>
+      <p>Get up and running in minutes.</p>
+      <a href="#quick-start"><strong>Read guide →</strong></a>
+    </td>
+    <td>
+      <h3>📖 API Docs</h3>
+      <p>Complete reference with request & response examples.</p>
+      <a href="docs/api.md"><strong>Explore →</strong></a>
+    </td>
+    <td>
+      <h3>🏗️ Architecture</h3>
+      <p>Deep dive into the system design and patterns.</p>
+      <a href="docs/architecture.md"><strong>Understand →</strong></a>
+    </td>
+    <td>
+      <h3>🚀 Deployment</h3>
+      <p>Production-ready deployment playbooks.</p>
+      <a href="docs/deployment.md"><strong>Deploy →</strong></a>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <h3>💻 Development</h3>
+      <p>Local setup, workflows, and contributor tooling.</p>
+      <a href="docs/development.md"><strong>Build →</strong></a>
+    </td>
+    <td>
+      <h3>🔧 Troubleshooting</h3>
+      <p>Quick fixes for common pitfalls and errors.</p>
+      <a href="docs/troubleshooting.md"><strong>Fix →</strong></a>
+    </td>
+    <td>
+      <h3>🤝 Contributing</h3>
+      <p>Guidelines for issues, pull requests, and reviews.</p>
+      <a href="docs/contributing.md"><strong>Join →</strong></a>
+    </td>
+    <td>
+      <h3>📋 Changelog</h3>
+      <p>Track version history and notable updates.</p>
+      <a href="docs/changelog.md"><strong>Review →</strong></a>
+    </td>
+  </tr>
+</table>
+
+</div>
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary
- restyle the documentation section in the README with a centered grid layout
- present each guide as a card with headings, descriptions, and call-to-action links

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d962f65cec832b9644989f0e30b950