### PR TITLE
chore: add transcribe-clip target for clipboard output

### DIFF
--- a/.plan/.done/chore-add-clipboard-make-targets/PLAN.md
+++ b/.plan/.done/chore-add-clipboard-make-targets/PLAN.md
@@ -1,0 +1,43 @@
+# Plan: Add Clipboard-Friendly Make Targets
+
+## Status: COMPLETE
+
+## Problem
+
+`make transcribe URL='...'` produces verbose output; users want clean transcript on clipboard.
+
+## Solution Implemented
+
+### 1. Added cross-platform clipboard detection to Makefile
+
+```makefile
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+    CLIP_CMD = pbcopy
+else
+    # Linux: prefer xclip, fallback to xsel
+    ...
+endif
+```
+
+### 2. Added `transcribe-clip` target
+
+Extracts transcript between `--- Transcript ---` and `--- Segments ---` markers, pipes to clipboard, confirms with "Transcript copied to clipboard".
+
+### 3. Documented CLI pipeline patterns
+
+Added to `docs/development.md`:
+- `make transcribe-clip` usage
+- Manual pipeline patterns for custom filtering
+- Examples for transcript, segments, file output
+
+## Files Modified
+
+1. `makefile` - Added CLIP_CMD detection + transcribe-clip target
+2. `docs/development.md` - Added clipboard and pipeline documentation
+3. `CLAUDE.md` - Added transcribe-clip to command reference
+
+## Verification
+
+- [x] `make help` shows transcribe-clip target
+- [ ] Actual transcription test (requires whisper model)

--- a/.plan/backlog.json
+++ b/.plan/backlog.json
@@ -1,6 +1,18 @@
 {
-  "lastSequence": 11,
+  "lastSequence": 12,
   "items": [
+    {
+      "id": 12,
+      "title": "Add clipboard-friendly Make targets for transcription output",
+      "description": "Add Make targets that pipe transcript output directly to clipboard (pbcopy on macOS, xclip on Linux). Current `make transcribe` produces verbose terminal output; users want clean transcript on clipboard. Add `make transcribe-clip` for transcript-only and document CLI pipeline patterns.",
+      "category": "chore",
+      "severity": "medium",
+      "fingerprint": "chore|12|add-clipboard-make-targets",
+      "source": "/pro:chore",
+      "sourceBranch": "chore/add-clipboard-make-targets",
+      "createdAt": "2026-03-30T12:00:00Z",
+      "status": "in-progress"
+    },
     {
       "id": 11,
       "title": "Fix YouTube Shorts 403 Forbidden download error",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,9 +37,10 @@ make build         # Build application
 make clean         # Clean all build artifacts
 
 # CLI transcription (no server needed)
-make transcribe URL="https://www.youtube.com/watch?v=..."     # Transcribe any URL
-make transcribe URL="https://www.instagram.com/reel/ABC123/" # Instagram, TikTok, etc.
-make transcribe URL="/path/to/video.mp4"                     # Local file
+make transcribe URL="https://www.youtube.com/watch?v=..."      # Transcribe any URL
+make transcribe URL="https://www.instagram.com/reel/ABC123/"  # Instagram, TikTok, etc.
+make transcribe URL="/path/to/video.mp4"                      # Local file
+make transcribe-clip URL="..."                                 # Transcript to clipboard
 
 # Testing & quality
 make test          # Run all tests including load tests

--- a/docs/development.md
+++ b/docs/development.md
@@ -100,6 +100,37 @@ The CLI tool directly uses the `engine/` package (ADR-0001: Dual Consumption Mod
 - Scripting and automation
 - Debugging the transcription pipeline
 
+#### Copy Transcript to Clipboard
+
+For quick access to transcripts without scrolling through terminal output:
+
+```bash
+# Transcribe and copy directly to clipboard (macOS/Linux)
+make transcribe-clip URL="https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+# Output: "Transcript copied to clipboard"
+```
+
+#### CLI Pipeline Patterns
+
+For custom output handling, pipe the standard `transcribe` output:
+
+```bash
+# Extract just the transcript (between markers)
+make transcribe URL="..." 2>&1 | sed -n '/^--- Transcript ---$/,/^--- Segments ---$/p' | sed '1d;$d'
+
+# Copy transcript to clipboard manually (macOS)
+make transcribe URL="..." 2>&1 | sed -n '/^--- Transcript ---$/,/^--- Segments ---$/p' | sed '1d;$d' | pbcopy
+
+# Copy transcript to clipboard manually (Linux with xclip)
+make transcribe URL="..." 2>&1 | sed -n '/^--- Transcript ---$/,/^--- Segments ---$/p' | sed '1d;$d' | xclip -selection clipboard
+
+# Save transcript to file
+make transcribe URL="..." 2>&1 | sed -n '/^--- Transcript ---$/,/^--- Segments ---$/p' | sed '1d;$d' > transcript.txt
+
+# Extract timestamped segments
+make transcribe URL="..." 2>&1 | sed -n '/^--- Segments ---$/,/^--- Summary ---$/p' | sed '1d;$d'
+```
+
 ### Development Server Options
 
 #### Option 1: Standard Go Server (Fiber)

--- a/makefile
+++ b/makefile
@@ -29,6 +29,21 @@ YELLOW=\033[1;33m
 RED=\033[0;31m
 NC=\033[0m # No Color
 
+# Clipboard command (cross-platform)
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+    CLIP_CMD = pbcopy
+else
+    # Linux: prefer xclip, fallback to xsel
+    ifneq ($(shell which xclip 2>/dev/null),)
+        CLIP_CMD = xclip -selection clipboard
+    else ifneq ($(shell which xsel 2>/dev/null),)
+        CLIP_CMD = xsel --clipboard --input
+    else
+        CLIP_CMD = cat > /dev/null && echo "$(YELLOW)No clipboard tool found (install xclip or xsel)$(NC)"
+    endif
+endif
+
 .PHONY: help
 help: ## Show this help message
 	@echo "$(BLUE)OmniTranscripts - Available Commands$(NC)"
@@ -76,6 +91,21 @@ endif
 	@mkdir -p $(BUILD_DIR)
 	@CGO_ENABLED=1 go build -o $(BUILD_DIR)/transcribe examples/transcribe/main.go
 	@WHISPER_MODEL_PATH=models/ggml-base.en.bin $(BUILD_DIR)/transcribe "$(URL)"
+
+.PHONY: transcribe-clip
+transcribe-clip: ## Transcribe URL and copy transcript to clipboard
+ifndef URL
+	@echo "$(RED)Error: URL is required$(NC)"
+	@echo "Usage: make transcribe-clip URL=\"https://...\""
+	@exit 1
+endif
+	@mkdir -p $(BUILD_DIR)
+	@CGO_ENABLED=1 go build -o $(BUILD_DIR)/transcribe examples/transcribe/main.go 2>/dev/null
+	@WHISPER_MODEL_PATH=models/ggml-base.en.bin $(BUILD_DIR)/transcribe "$(URL)" 2>&1 | \
+		sed -n '/^--- Transcript ---$$/,/^--- Segments ---$$/p' | \
+		sed '1d;$$d' | \
+		$(CLIP_CMD)
+	@echo "$(GREEN)Transcript copied to clipboard$(NC)"
 
 ##@ Building
 .PHONY: build


### PR DESCRIPTION
## Summary

- Add `make transcribe-clip URL="..."` target that copies transcript directly to clipboard
- Cross-platform support: `pbcopy` (macOS), `xclip`/`xsel` (Linux)
- Document CLI pipeline patterns for advanced output handling

## Changes

| File | Change |
|------|--------|
| `makefile` | Add CLIP_CMD detection + transcribe-clip target |
| `docs/development.md` | Add clipboard + pipeline docs |
| `CLAUDE.md` | Update command reference |

## Usage

```bash
# Transcribe and copy to clipboard
make transcribe-clip URL="https://www.youtube.com/watch?v=..."
# Output: "Transcript copied to clipboard"
```

## Test plan

- [x] `make help` shows new target
- [ ] Verify on macOS with pbcopy
- [ ] Verify on Linux with xclip/xsel