### PR TITLE
feat: add CLI download target to Makefile

### DIFF
--- a/.plan/fix-file-uri-local-path-handling/PLAN.md
+++ b/.plan/fix-file-uri-local-path-handling/PLAN.md
@@ -1,0 +1,92 @@
+# Bug Fix: Local file handling in CLI and engine
+
+## Status: COMPLETE
+
+## Bug Details
+
+**Steps to Reproduce:**
+```bash
+make transcribe URL='file://Users/wilmooreiii/Downloads/video.mp4'
+```
+
+**Expected:** Transcribes the local file directly without downloading
+
+**Actual (Bug 1 - CLI):**
+```
+Error: File not found: file://Users/wilmooreiii/Downloads/video.mp4
+```
+
+**Actual (Bug 2 - Engine):**
+```
+Transcription failed at stage 'download': failed to download audio
+  Cause: yt-dlp failed: exit code 1
+ERROR: [generic] '/Users/.../video.mp4' is not a valid URL
+```
+
+**Severity:** High (blocks local file transcription entirely)
+
+## Root Causes
+
+### Bug 1: CLI doesn't handle file:// URIs
+In `examples/transcribe/main.go:32`, URL detection only checks for `http://` and `https://`.
+When `file://` URI is passed, it's treated as a literal filesystem path.
+
+### Bug 2: Engine always uses yt-dlp
+In `engine/engine.go`, the `Transcribe()` function always calls `downloadAudio()` which uses yt-dlp.
+It doesn't detect whether the input is already a local file.
+
+## Fixes
+
+### Fix 1: CLI file:// URI handling
+```go
+// Handle file:// URIs by converting to local path
+if strings.HasPrefix(input, "file://") {
+    input = strings.TrimPrefix(input, "file://")
+    if !strings.HasPrefix(input, "/") {
+        input = "/" + input
+    }
+}
+```
+
+### Fix 2: Engine local file detection
+```go
+func isLocalFile(input string) bool {
+    if strings.HasPrefix(input, "http://") || strings.HasPrefix(input, "https://") {
+        return false
+    }
+    _, err := os.Stat(input)
+    return err == nil
+}
+
+// In Transcribe():
+if isLocalFile(url) {
+    // Local file: skip download, normalize directly
+    if err := normalizeAudio(ctx, url, normalizedAudio); err != nil {
+        return nil, NewError(StageNormalize, "failed to normalize audio", err)
+    }
+} else {
+    // URL: download via yt-dlp, then normalize
+    ...
+}
+```
+
+## Verification
+
+```bash
+# Before fix
+$ make transcribe URL='file://Users/.../video.mp4'
+ERROR: [generic] '/Users/.../video.mp4' is not a valid URL
+
+# After fix
+$ make transcribe URL='file://Users/.../video.mp4'
+Transcribing: /Users/.../video.mp4
+Type: Local file
+Processing local file: /Users/.../video.mp4
+--- Transcript ---
+...
+```
+
+## Files Modified
+
+1. `examples/transcribe/main.go` - Add file:// URI handling
+2. `engine/engine.go` - Add isLocalFile() and skip download for local files

--- a/.plan/refactor-add-cli-transcribe-target/PLAN.md
+++ b/.plan/refactor-add-cli-transcribe-target/PLAN.md
@@ -1,0 +1,23 @@
+# Add CLI Transcribe Target
+
+**Branch:** `refactor/add-cli-transcribe-target`
+**Status:** Planning
+**Backlog ID:** 10
+
+## Summary
+
+Add `make transcribe URL="..."` for quick one-off transcriptions without starting the HTTP server.
+
+## Implementation
+
+1. Move `examples/local-files/transcribe.go` → `examples/transcribe/main.go`
+2. Remove file-exists check (URLs work via yt-dlp)
+3. Add Makefile target with URL validation
+4. Update docs
+
+## Files
+
+- `Makefile` - Add ##@ CLI section with transcribe target
+- `examples/transcribe/main.go` - Relocated CLI tool
+- `CLAUDE.md` - Document new command
+- `docs/development.md` - Usage examples

--- a/.plan/refactor-add-cli-transcribe-target/errors.json
+++ b/.plan/refactor-add-cli-transcribe-target/errors.json
@@ -1,0 +1,42 @@
+{
+  "attempts": [
+    {
+      "timestamp": "2026-02-09T02:22:19Z",
+      "tool": "Bash",
+      "error": "go build ./examples/transcribe/...",
+      "status": "unresolved"
+    },
+    {
+      "timestamp": "2026-02-09T02:47:00Z",
+      "tool": "Bash",
+      "error": "rm -f /tmp/omnitranscripts/cli-transcribe* && make transcribe URL=\"https://www.instagram.com/reel/DNYmwU6RJ2m/\" 2>&1",
+      "status": "unresolved"
+    },
+    {
+      "timestamp": "2026-02-09T02:47:21Z",
+      "tool": "Bash",
+      "error": "make transcribe URL=\"https://www.instagram.com/reel/DNYmwU6RJ2m/\" 2>&1",
+      "status": "unresolved"
+    },
+    {
+      "timestamp": "2026-02-09T02:48:16Z",
+      "tool": "Bash",
+      "error": "make transcribe URL=\"https://www.instagram.com/reel/DNYmwU6RJ2m/\" 2>&1",
+      "status": "unresolved"
+    },
+    {
+      "timestamp": "2026-02-11T02:23:44Z",
+      "tool": "Bash",
+      "error": "make transcribe URL=\"https://www.loom.com/share/2fdd8217b94d4cdca5429aea3a010625\" 2>&1",
+      "status": "unresolved"
+    },
+    {
+      "timestamp": "2026-02-11T02:25:10Z",
+      "tool": "Bash",
+      "error": "make transcribe URL=\"https://www.loom.com/share/2fdd8217b94d4cdca5429aea3a010625\" 2>&1",
+      "status": "unresolved"
+    }
+  ],
+  "strikeCount": 2,
+  "lastErrorHash": "d61420a2"
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,9 @@ make test-short    # Run quick tests (skip load tests)
 make build         # Build application
 make clean         # Clean all build artifacts
 
-# CLI transcription (no server needed)
+# CLI media operations (no server needed)
+make download URL="https://music.youtube.com/watch?v=..."     # Download media to ~/Downloads
+make download URL="https://..." OUT=./video.mp4               # Download to custom path
 make transcribe URL="https://www.youtube.com/watch?v=..."     # Transcribe any URL
 make transcribe URL="https://www.instagram.com/reel/ABC123/" # Instagram, TikTok, etc.
 make transcribe URL="/path/to/video.mp4"                     # Local file

--- a/doc/.plan/session-handoff.md
+++ b/doc/.plan/session-handoff.md
@@ -1,0 +1,31 @@
+# Session Handoff Ledger
+
+Updated: 2026-04-14T00:08:49.648Z
+Current session: session-2026-04-14T00-08-49-595Z-4e78988f
+
+## Outstanding Snapshots (1)
+
+1. [pending] session-2026-04-14T00-08-49-595Z-4e78988f — feat/add-download-make-target (dirty)
+   File: doc/.plan/session-handoff/sessions/session-2026-04-14T00-08-49-595Z-4e78988f.md
+   Updated: 2026-04-14T00:08:49.595Z
+
+## Recent Activity
+
+- None
+
+## Commands
+
+Run these from the client project root (adjust $HOME/.config if you use a custom config home):
+
+- `node "$HOME/.config/opencode/bin/session-handoff.mjs" list` — show pending snapshots
+- `node "$HOME/.config/opencode/bin/session-handoff.mjs" ack <id> [--note "done"]` — mark complete
+- `node "$HOME/.config/opencode/bin/session-handoff.mjs" dismiss <id> --reason "why"` — abandon work
+- `node "$HOME/.config/opencode/bin/session-handoff.mjs" write --trigger "/pro:session.handoff"` — capture a fresh snapshot
+
+If you vendor the CLI into a repo instead:
+
+- `node bin/session-handoff.mjs list|ack|dismiss|write ...`
+
+Compatibility note: some older snapshot files may still mention `node bin/session-handoff.mjs ...`. If your repo does not contain that file, use the globally installed CLI commands listed above.
+
+All snapshots live under `doc/.plan/session-handoff/sessions/`. Review each file before acknowledging or dismissing it.

--- a/doc/.plan/session-handoff/index.json
+++ b/doc/.plan/session-handoff/index.json
@@ -1,0 +1,18 @@
+{
+  "version": 1,
+  "sessions": [
+    {
+      "id": "session-2026-04-14T00-08-49-595Z-4e78988f",
+      "filename": "session-2026-04-14T00-08-49-595Z-4e78988f.md",
+      "relativePath": "sessions/session-2026-04-14T00-08-49-595Z-4e78988f.md",
+      "status": "pending",
+      "createdAt": "2026-04-14T00:08:49.595Z",
+      "updatedAt": "2026-04-14T00:08:49.595Z",
+      "trigger": "plugin.initialize",
+      "branch": "feat/add-download-make-target",
+      "workingTree": "dirty",
+      "recentCommit": "dd0444e Merge pull request #11 from wilmoore/fix/yt-dlp-youtube-shorts-403",
+      "backlogSummary": "- In-progress items: unknown (no readable backlog)"
+    }
+  ]
+}

--- a/doc/.plan/session-handoff/sessions/session-2026-04-14T00-08-49-595Z-4e78988f.md
+++ b/doc/.plan/session-handoff/sessions/session-2026-04-14T00-08-49-595Z-4e78988f.md
@@ -1,0 +1,34 @@
+# Session Handoff Snapshot
+
+ID: session-2026-04-14T00-08-49-595Z-4e78988f
+Status: pending
+Created: 2026-04-14T00:08:49.595Z
+Updated: 2026-04-14T00:08:49.595Z
+Trigger: plugin.initialize
+
+## Current State
+
+- Branch: `feat/add-download-make-target`
+- Working tree: dirty
+- Last commit: `dd0444e Merge pull request #11 from wilmoore/fix/yt-dlp-youtube-shorts-403`
+- In-progress items: unknown (no readable backlog)
+
+## Next Steps
+
+1. Review the outstanding checklist stored in this file.
+2. Once complete, acknowledge the snapshot (run from the client project root):
+   ```bash
+   node "$HOME/.config/opencode/bin/session-handoff.mjs" ack session-2026-04-14T00-08-49-595Z-4e78988f
+   ```
+   If you have vendored the CLI into the repo, this also works:
+   ```bash
+   node bin/session-handoff.mjs ack session-2026-04-14T00-08-49-595Z-4e78988f
+   ```
+3. If the work is obsolete, dismiss it instead (run from the client project root):
+   ```bash
+   node "$HOME/.config/opencode/bin/session-handoff.mjs" dismiss session-2026-04-14T00-08-49-595Z-4e78988f --reason "why"
+   ```
+   Vendored alternative:
+   ```bash
+   node bin/session-handoff.mjs dismiss session-2026-04-14T00-08-49-595Z-4e78988f --reason "why"
+   ```

--- a/examples/download/main.go
+++ b/examples/download/main.go
@@ -1,0 +1,153 @@
+// CLI tool for downloading media from any URL using yt-dlp
+//
+// Supports:
+//   - YouTube, YouTube Music, Instagram, TikTok, Vimeo, and 1000+ platforms
+//   - Auto-detects best format (audio for music URLs, video otherwise)
+//
+// Usage:
+//
+//	go run main.go <url> [output_path]
+//	make download URL="https://music.youtube.com/watch?v=..."
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/lrstanley/go-ytdlp"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		printUsage()
+		os.Exit(1)
+	}
+
+	url := os.Args[1]
+	outputPath := ""
+	if len(os.Args) >= 3 && os.Args[2] != "" {
+		outputPath = os.Args[2]
+	}
+
+	// Default to ~/Downloads if no output specified
+	if outputPath == "" {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			fmt.Printf("Error: Could not determine home directory: %v\n", err)
+			os.Exit(1)
+		}
+		outputPath = filepath.Join(homeDir, "Downloads")
+	}
+
+	// Ensure output directory exists
+	outputDir := outputPath
+	if !isDirectory(outputPath) {
+		outputDir = filepath.Dir(outputPath)
+	}
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		fmt.Printf("Error: Could not create output directory: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("URL: %s\n", url)
+	fmt.Printf("Output: %s\n", outputPath)
+
+	// Detect if this is likely an audio-only source
+	isAudioSource := isAudioURL(url)
+	if isAudioSource {
+		fmt.Println("Type: Audio (music source detected)")
+	} else {
+		fmt.Println("Type: Video")
+	}
+	fmt.Println()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
+
+	// Install bundled yt-dlp
+	if _, err := ytdlp.Install(ctx, &ytdlp.InstallOptions{DisableSystem: true}); err != nil {
+		fmt.Printf("Error: Failed to install yt-dlp: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Configure yt-dlp based on content type
+	dl := ytdlp.New()
+
+	if isAudioSource {
+		// Audio: extract best audio format
+		dl = dl.ExtractAudio().AudioQuality("0")
+	}
+
+	// Set output template
+	if isDirectory(outputPath) {
+		// Directory: use default filename
+		dl = dl.Output(filepath.Join(outputPath, "%(title)s.%(ext)s"))
+	} else {
+		// Specific file path
+		dl = dl.Output(outputPath)
+	}
+
+	// Run download
+	fmt.Println("Downloading...")
+	result, err := dl.Run(ctx, url)
+	if err != nil {
+		fmt.Printf("Download failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	if result.ExitCode != 0 {
+		fmt.Printf("Download failed (exit code %d): %s\n", result.ExitCode, result.Stderr)
+		os.Exit(1)
+	}
+
+	fmt.Println()
+	fmt.Println("Download complete!")
+}
+
+// isAudioURL detects if the URL is likely an audio-only source
+func isAudioURL(url string) bool {
+	audioPatterns := []string{
+		"music.youtube.com",
+		"soundcloud.com",
+		"spotify.com",
+		"bandcamp.com",
+		"audiomack.com",
+		"mixcloud.com",
+	}
+
+	urlLower := strings.ToLower(url)
+	for _, pattern := range audioPatterns {
+		if strings.Contains(urlLower, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+// isDirectory checks if path is an existing directory
+func isDirectory(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return info.IsDir()
+}
+
+func printUsage() {
+	fmt.Println("Usage: go run main.go <url> [output_path]")
+	fmt.Println()
+	fmt.Println("Examples:")
+	fmt.Println("  # Download to ~/Downloads/")
+	fmt.Println("  go run main.go https://music.youtube.com/watch?v=...")
+	fmt.Println()
+	fmt.Println("  # Download to specific location")
+	fmt.Println("  go run main.go https://www.youtube.com/watch?v=... ./video.mp4")
+	fmt.Println()
+	fmt.Println("Or use the Makefile:")
+	fmt.Println("  make download URL=\"https://...\"")
+	fmt.Println("  make download URL=\"https://...\" OUT=./my-file.mp4")
+}

--- a/makefile
+++ b/makefile
@@ -60,6 +60,25 @@ run: ## Run the application
 	@CGO_ENABLED=$(CGO_ENABLED) go run .
 
 ##@ CLI
+.PHONY: download
+download: ## Download media from URL (make download URL="..." [OUT=path])
+ifndef URL
+	@echo "$(RED)Error: URL is required$(NC)"
+	@echo "Usage: make download URL=\"https://...\""
+	@echo ""
+	@echo "Options:"
+	@echo "  OUT=path    Override output location (default: ~/Downloads/)"
+	@echo ""
+	@echo "Examples:"
+	@echo "  make download URL=\"https://music.youtube.com/watch?v=...\""
+	@echo "  make download URL=\"https://www.youtube.com/watch?v=...\" OUT=./video.mp4"
+	@exit 1
+endif
+	@echo "$(BLUE)Downloading: $(URL)$(NC)"
+	@mkdir -p $(BUILD_DIR)
+	@CGO_ENABLED=0 go build -o $(BUILD_DIR)/download examples/download/main.go
+	@$(BUILD_DIR)/download "$(URL)" "$(OUT)"
+
 .PHONY: transcribe
 transcribe: ## Transcribe a URL or file (make transcribe URL="https://...")
 ifndef URL


### PR DESCRIPTION
## Summary

Add a `make download URL='...' [OUT=path]` target for quick media downloads without starting the HTTP server.

## Features

- **Auto-detects content type**: Music URLs extract audio only, other content downloads as video
- **Flexible output**: Default to ~/Downloads or specify custom output path
- **Platform support**: Works with YouTube, YouTube Music, Instagram, TikTok, Vimeo, and 1000+ platforms
- **Bundled yt-dlp**: Uses go-ytdlp for reliable cross-platform support

## Changes

- `makefile`: Add `##@ CLI` section with download target
- `examples/download/main.go`: New CLI tool for media downloads
- `CLAUDE.md`: Documented new command in development guide

## Usage

```bash
# Download to ~/Downloads (auto-detected format)
make download URL="https://music.youtube.com/watch?v=..."

# Download to custom path
make download URL="https://www.youtube.com/watch?v=..." OUT=./video.mp4
```

## Related Issues

Closes #10 (Add CLI transcribe target to Makefile) - this complements the existing `make transcribe` CLI tool.