### PR TITLE
chore: make transcribe output clipboard-friendly

### DIFF
--- a/.plan/.done/chore-fix-clipboard-transcribe-output/plan.md
+++ b/.plan/.done/chore-fix-clipboard-transcribe-output/plan.md
@@ -131,3 +131,7 @@ make transcribe URL='...' > transcript.txt
 make transcribe URL='...' 2>/dev/null | wc -w  # Word count
 make transcribe URL='...' | grep -i "keyword"  # Search content
 ```
+
+## Related ADRs
+
+- [0005. Separate CLI Data and Diagnostic Streams](../../../doc/decisions/0005-separate-cli-data-and-diagnostic-streams.md)

--- a/.plan/adr-index.json
+++ b/.plan/adr-index.json
@@ -1,5 +1,5 @@
 {
-  "lastSequence": 4,
+  "lastSequence": 5,
   "entries": [
     {
       "branch": "feature/rename-omnitranscripts",
@@ -20,6 +20,10 @@
     {
       "branch": "fix/yt-dlp-youtube-shorts-403",
       "adrs": ["0004-ytdlp-dependency-management.md"]
+    },
+    {
+      "branch": "chore/fix-clipboard-transcribe-output",
+      "adrs": ["0005-separate-cli-data-and-diagnostic-streams.md"]
     }
   ]
 }

--- a/.plan/backlog.json
+++ b/.plan/backlog.json
@@ -1,5 +1,5 @@
 {
-  "lastSequence": 11,
+  "lastSequence": 12,
   "items": [
     {
       "id": 11,
@@ -139,6 +139,18 @@
       "sourceBranch": "main",
       "createdAt": "2026-01-10T09:43:37Z",
       "status": "pending"
+    },
+    {
+      "id": 12,
+      "title": "Add clipboard support to transcribe CLI",
+      "description": "Add make transcribe-clip target that automatically copies transcript to clipboard (cross-platform: macOS pbcopy, Linux xclip/xsel). Enables quick clipboard workflows for transcript extraction.",
+      "category": "chore",
+      "severity": "medium",
+      "fingerprint": "chore|12|clipboard-transcribe-output",
+      "source": "/pro:chore",
+      "sourceBranch": "chore/fix-clipboard-transcribe-output",
+      "createdAt": "2026-05-13T22:50:22Z",
+      "status": "in-progress"
     }
   ]
 }

--- a/.plan/backlog.json
+++ b/.plan/backlog.json
@@ -150,7 +150,7 @@
       "source": "/pro:chore",
       "sourceBranch": "chore/fix-clipboard-transcribe-output",
       "createdAt": "2026-05-13T22:50:22Z",
-      "status": "in-progress"
+      "status": "completed"
     }
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,50 @@ go test -v -run TestPostTranscribe_ValidationErrors ./handlers
 
 **Complete command reference and development workflows:** [docs/development.md](docs/development.md)
 
+## CLI Output and Piping
+
+The `make transcribe` command outputs the transcript text to stdout and progress/diagnostics to stderr. This enables natural Unix piping for flexible workflows:
+
+### Copy transcript to clipboard
+```bash
+# macOS
+make transcribe URL="https://www.youtube.com/watch?v=dQw4w9WgXcQ" | pbcopy
+
+# Linux (xclip)
+make transcribe URL="https://www.youtube.com/watch?v=dQw4w9WgXcQ" | xclip -selection clipboard
+
+# Linux (xsel)
+make transcribe URL="https://www.youtube.com/watch?v=dQw4w9WgXcQ" | xsel --clipboard --input
+```
+
+### Save transcript to file
+```bash
+make transcribe URL="https://www.youtube.com/watch?v=dQw4w9WgXcQ" > transcript.txt
+make transcribe URL="https://www.instagram.com/reel/ABC123/" >> all-transcripts.txt
+```
+
+### Suppress progress output
+```bash
+make transcribe URL="https://www.youtube.com/watch?v=dQw4w9WgXcQ" 2>/dev/null | pbcopy
+```
+
+### Pipe to other tools
+```bash
+# Word count
+make transcribe URL="..." 2>/dev/null | wc -w
+
+# Search for keywords
+make transcribe URL="..." | grep -i "keyword"
+
+# Get first 20 lines
+make transcribe URL="..." | head -20
+
+# Line count
+make transcribe URL="..." 2>/dev/null | wc -l
+```
+
+**Note:** Progress and diagnostic information appears on stderr, allowing you to see transcription status while safely piping stdout to other commands.
+
 Environment configuration via `.env` file:
 ```bash
 PORT=3000

--- a/doc/.plan/chore-fix-clipboard-transcribe-output/PLAN.md
+++ b/doc/.plan/chore-fix-clipboard-transcribe-output/PLAN.md
@@ -1,0 +1,133 @@
+# Chore: Fix Clipboard Transcribe Output
+
+**Branch:** `chore/fix-clipboard-transcribe-output`
+**Status:** Completed
+**Issue:** `make transcribe URL='...'` does not copy transcript to clipboard properly due to mixed stdout/stderr output
+
+## Problem Summary
+
+Users expect the `make transcribe` command to copy the transcript output to the clipboard (similar to other CLI tools), but currently:
+1. The transcript is only printed to stdout
+2. The user must manually select and copy the output
+3. There is no clipboard integration in the transcribe Makefile target
+
+## Root Cause
+
+The `chore/add-clipboard-make-targets` branch exists with a `transcribe-clip` target that has the implementation, but:
+1. This branch is not merged to main
+2. The clipboard infrastructure (CLIP_CMD variable) is not on main
+3. No clipboard target is available on the current main branch
+
+## Scope
+
+This chore will:
+1. Add cross-platform clipboard command detection to makefile (CLIP_CMD)
+2. Create a `make transcribe-clip URL="..."` target that pipes transcript to clipboard
+3. Optionally make `make transcribe` also copy to clipboard (design decision needed)
+4. Document the new commands in CLAUDE.md and development guide
+
+## Design Decision: Unix/GNU Philosophy
+
+Per user feedback, the solution should follow Unix principles:
+- **stdout**: Clean transcript text only (composable)
+- **stderr**: Error messages (can be redirected to /dev/null)
+- **Usage**: `make transcribe URL="..." | pbcopy` (or pipe to other tools)
+- **No special transcribe-clip target needed** - just proper output handling
+
+This enables natural shell composition like:
+- `make transcribe URL="..." | pbcopy` - copy to clipboard
+- `make transcribe URL="..." > file.txt` - save to file
+- `make transcribe URL="..." 2>/dev/null | pbcopy` - suppress errors
+
+## Implementation Plan
+
+1. **Update transcribe CLI** (examples/transcribe/main.go):
+   - Print only transcript text to stdout (no headers, no segments)
+   - Keep all diagnostic output to stderr
+   - Use exit code for success/failure
+
+2. **Create sh wrapper** or **Makefile target** for convenience:
+   - Optional: Add `make transcribe-clip` for one-liner clipboard copy
+   - But main usage: `make transcribe URL="..." | pbcopy`
+
+3. **Update documentation** in CLAUDE.md with examples
+
+## Files to Modify
+
+- `examples/transcribe/main.go` - Make stdout only transcript text
+- `makefile` - Update transcribe target output handling
+- `CLAUDE.md` - Document output piping patterns
+- `docs/development.md` - Add usage examples with pipes
+
+## Implementation Summary
+
+### ✅ Completed Changes
+
+**1. CLI Output Separation (examples/transcribe/main.go)**
+- All diagnostic output (progress, errors, summary) moved to stderr using fmt.Fprintf(os.Stderr, ...)
+- Only transcript text output to stdout (fmt.Fprint(os.Stdout, result.Transcript))
+- Exit codes: 0 for success, 1 for errors
+- File-not-found and other validation errors correctly routed to stderr
+
+**2. CLAUDE.md - Added "CLI Output and Piping" Section**
+- Copy to clipboard on macOS (pbcopy) and Linux (xclip/xsel)
+- Save to file examples
+- Suppress progress output (2>/dev/null)
+- Pipe to other tools (wc, grep, head)
+- Note about stderr carrying diagnostics
+
+**3. docs/development.md - Expanded CLI Section**
+- Added "CLI Output and Piping" subsection
+- Copy to clipboard examples
+- Save to file examples
+- Suppress progress output
+- Get transcript statistics (word count, line count, search, slicing)
+- Explanation of why streams are separated
+
+**4. readme.md - Added "Command-Line Interface (CLI)" Section**
+- Quick reference for clipboard, file, and statistics use cases
+- Lists benefits of CLI (no server overhead, automation, scripting, CI/CD)
+
+**5. docs/troubleshooting.md - Added "CLI and Output Issues" Section**
+- Clipboard tool installation guides for:
+  - macOS (pbcopy via Command Line Tools)
+  - Linux (xclip/xsel with package manager instructions)
+  - Windows WSL (clip.exe)
+- Troubleshooting: transcript not appearing, too much output
+- Fallback options when clipboard tools unavailable
+
+**6. docs/api.md - Added "Command-Line Interface (CLI)" Section**
+- Basic usage examples
+- Output handling explanation
+- Copy to clipboard (all platforms)
+- Save to file
+- Suppress progress output
+- Text processing examples (wc, grep, head)
+- Exit codes documentation
+
+### Test Results
+
+✅ Build successful (CGO_ENABLED=1)
+✅ CLI binary builds without errors
+✅ Usage output goes to stderr
+✅ Error handling outputs to stderr
+✅ Makefile transcribe target recognized
+
+### How Users Can Now Use It
+
+```bash
+# Before: No clean way to copy to clipboard
+make transcribe URL='...'  # Mixed output, can't pipe cleanly
+
+# After: Clean piping to clipboard
+make transcribe URL='https://www.youtube.com/watch?v=zHStoIheM7M' | pbcopy
+make transcribe URL='...' | xclip -selection clipboard  # Linux
+make transcribe URL='...' 2>/dev/null | pbcopy           # Suppress progress
+
+# Save to file
+make transcribe URL='...' > transcript.txt
+
+# Get statistics
+make transcribe URL='...' 2>/dev/null | wc -w  # Word count
+make transcribe URL='...' | grep -i "keyword"  # Search content
+```

--- a/doc/.plan/session-handoff.md
+++ b/doc/.plan/session-handoff.md
@@ -1,13 +1,21 @@
 # Session Handoff Ledger
 
-Updated: 2026-04-14T00:08:49.648Z
-Current session: session-2026-04-14T00-08-49-595Z-4e78988f
+Updated: 2026-05-13T20:49:35.950Z
+Current session: session-2026-05-13T20-49-35-912Z-5af4f328
 
-## Outstanding Snapshots (1)
+## Outstanding Snapshots (3)
 
 1. [pending] session-2026-04-14T00-08-49-595Z-4e78988f — feat/add-download-make-target (dirty)
    File: doc/.plan/session-handoff/sessions/session-2026-04-14T00-08-49-595Z-4e78988f.md
    Updated: 2026-04-14T00:08:49.595Z
+
+2. [pending] session-2026-05-13T20-49-34-584Z-fe6e7d3b — main (clean)
+   File: doc/.plan/session-handoff/sessions/session-2026-05-13T20-49-34-584Z-fe6e7d3b.md
+   Updated: 2026-05-13T20:49:34.584Z
+
+3. [pending] session-2026-05-13T20-49-35-912Z-5af4f328 — main (dirty)
+   File: doc/.plan/session-handoff/sessions/session-2026-05-13T20-49-35-912Z-5af4f328.md
+   Updated: 2026-05-13T20:49:35.912Z
 
 ## Recent Activity
 

--- a/doc/.plan/session-handoff/index.json
+++ b/doc/.plan/session-handoff/index.json
@@ -13,6 +13,32 @@
       "workingTree": "dirty",
       "recentCommit": "dd0444e Merge pull request #11 from wilmoore/fix/yt-dlp-youtube-shorts-403",
       "backlogSummary": "- In-progress items: unknown (no readable backlog)"
+    },
+    {
+      "id": "session-2026-05-13T20-49-34-584Z-fe6e7d3b",
+      "filename": "session-2026-05-13T20-49-34-584Z-fe6e7d3b.md",
+      "relativePath": "sessions/session-2026-05-13T20-49-34-584Z-fe6e7d3b.md",
+      "status": "pending",
+      "createdAt": "2026-05-13T20:49:34.584Z",
+      "updatedAt": "2026-05-13T20:49:34.584Z",
+      "trigger": "plugin.initialize",
+      "branch": "main",
+      "workingTree": "clean",
+      "recentCommit": "85e8b35 Merge pull request #13 from wilmoore/feat/add-download-make-target",
+      "backlogSummary": "- In-progress items: unknown (no readable backlog)"
+    },
+    {
+      "id": "session-2026-05-13T20-49-35-912Z-5af4f328",
+      "filename": "session-2026-05-13T20-49-35-912Z-5af4f328.md",
+      "relativePath": "sessions/session-2026-05-13T20-49-35-912Z-5af4f328.md",
+      "status": "pending",
+      "createdAt": "2026-05-13T20:49:35.912Z",
+      "updatedAt": "2026-05-13T20:49:35.912Z",
+      "trigger": "plugin.initialize",
+      "branch": "main",
+      "workingTree": "dirty",
+      "recentCommit": "85e8b35 Merge pull request #13 from wilmoore/feat/add-download-make-target",
+      "backlogSummary": "- In-progress items: unknown (no readable backlog)"
     }
   ]
 }

--- a/doc/.plan/session-handoff/sessions/session-2026-05-13T20-49-34-584Z-fe6e7d3b.md
+++ b/doc/.plan/session-handoff/sessions/session-2026-05-13T20-49-34-584Z-fe6e7d3b.md
@@ -1,0 +1,34 @@
+# Session Handoff Snapshot
+
+ID: session-2026-05-13T20-49-34-584Z-fe6e7d3b
+Status: pending
+Created: 2026-05-13T20:49:34.584Z
+Updated: 2026-05-13T20:49:34.584Z
+Trigger: plugin.initialize
+
+## Current State
+
+- Branch: `main`
+- Working tree: clean
+- Last commit: `85e8b35 Merge pull request #13 from wilmoore/feat/add-download-make-target`
+- In-progress items: unknown (no readable backlog)
+
+## Next Steps
+
+1. Review the outstanding checklist stored in this file.
+2. Once complete, acknowledge the snapshot (run from the client project root):
+   ```bash
+   node "$HOME/.config/opencode/bin/session-handoff.mjs" ack session-2026-05-13T20-49-34-584Z-fe6e7d3b
+   ```
+   If you have vendored the CLI into the repo, this also works:
+   ```bash
+   node bin/session-handoff.mjs ack session-2026-05-13T20-49-34-584Z-fe6e7d3b
+   ```
+3. If the work is obsolete, dismiss it instead (run from the client project root):
+   ```bash
+   node "$HOME/.config/opencode/bin/session-handoff.mjs" dismiss session-2026-05-13T20-49-34-584Z-fe6e7d3b --reason "why"
+   ```
+   Vendored alternative:
+   ```bash
+   node bin/session-handoff.mjs dismiss session-2026-05-13T20-49-34-584Z-fe6e7d3b --reason "why"
+   ```

--- a/doc/.plan/session-handoff/sessions/session-2026-05-13T20-49-35-912Z-5af4f328.md
+++ b/doc/.plan/session-handoff/sessions/session-2026-05-13T20-49-35-912Z-5af4f328.md
@@ -1,0 +1,34 @@
+# Session Handoff Snapshot
+
+ID: session-2026-05-13T20-49-35-912Z-5af4f328
+Status: pending
+Created: 2026-05-13T20:49:35.912Z
+Updated: 2026-05-13T20:49:35.912Z
+Trigger: plugin.initialize
+
+## Current State
+
+- Branch: `main`
+- Working tree: dirty
+- Last commit: `85e8b35 Merge pull request #13 from wilmoore/feat/add-download-make-target`
+- In-progress items: unknown (no readable backlog)
+
+## Next Steps
+
+1. Review the outstanding checklist stored in this file.
+2. Once complete, acknowledge the snapshot (run from the client project root):
+   ```bash
+   node "$HOME/.config/opencode/bin/session-handoff.mjs" ack session-2026-05-13T20-49-35-912Z-5af4f328
+   ```
+   If you have vendored the CLI into the repo, this also works:
+   ```bash
+   node bin/session-handoff.mjs ack session-2026-05-13T20-49-35-912Z-5af4f328
+   ```
+3. If the work is obsolete, dismiss it instead (run from the client project root):
+   ```bash
+   node "$HOME/.config/opencode/bin/session-handoff.mjs" dismiss session-2026-05-13T20-49-35-912Z-5af4f328 --reason "why"
+   ```
+   Vendored alternative:
+   ```bash
+   node bin/session-handoff.mjs dismiss session-2026-05-13T20-49-35-912Z-5af4f328 --reason "why"
+   ```

--- a/doc/decisions/0005-separate-cli-data-and-diagnostic-streams.md
+++ b/doc/decisions/0005-separate-cli-data-and-diagnostic-streams.md
@@ -1,0 +1,29 @@
+# 0005. Separate CLI Data and Diagnostic Streams
+
+Date: 2026-08-07
+
+## Status
+
+Accepted
+
+## Context
+
+The transcription CLI mixed progress messages, headings, segment metadata, and transcript text on standard output. Consumers therefore could not safely pipe the transcript to clipboard tools, files, or text-processing commands without also capturing diagnostic content.
+
+## Decision
+
+The transcribe command treats standard output as its data interface and writes only the transcript there. Usage text, progress, errors, and completion statistics are written to standard error. The Makefile wrapper follows the same contract so it does not contaminate the CLI output stream.
+
+## Consequences
+
+Shell pipelines can consume transcript text directly while diagnostics remain visible by default. Consumers that need a fully quiet command can redirect standard error. Human-readable segment and summary output is no longer included in standard output.
+
+## Alternatives Considered
+
+- Add a dedicated clipboard target, which would duplicate platform-specific shell behavior and reduce composability.
+- Keep mixed output and require downstream filtering, which would make the output format fragile and difficult to automate.
+- Hide diagnostics entirely, which would make long-running transcription work harder to observe and troubleshoot.
+
+## Related
+
+- Planning: `.plan/.done/chore-fix-clipboard-transcribe-output/`

--- a/doc/decisions/README.md
+++ b/doc/decisions/README.md
@@ -21,3 +21,4 @@ We use the [Michael Nygard format](https://cognitect.com/blog/2011/11/15/documen
 <!-- New ADRs added below -->
 - [002. Examples Directory for Usage Patterns](0002-examples-directory-for-usage-patterns.md)
 - [004. Async-First MCP Server Integration](0004-async-first-mcp-server-integration.md)
+- [005. Separate CLI Data and Diagnostic Streams](0005-separate-cli-data-and-diagnostic-streams.md)

--- a/docs/api.md
+++ b/docs/api.md
@@ -421,6 +421,86 @@ For detailed setup instructions, see [ChatGPT Integration Guide](chatgpt-integra
 
 ---
 
+## Command-Line Interface (CLI)
+
+The `make transcribe` command provides a convenient way to transcribe media without starting the HTTP server.
+
+### Basic Usage
+
+```bash
+# Transcribe a URL
+make transcribe URL="https://www.youtube.com/watch?v=VIDEO_ID"
+
+# Transcribe a local file
+make transcribe URL="/path/to/video.mp4"
+```
+
+### Output Handling
+
+The CLI outputs:
+- **stdout**: Clean transcript text (suitable for piping to other tools)
+- **stderr**: Progress messages and diagnostics
+
+This separation enables composable Unix workflows.
+
+### Copy to Clipboard
+
+```bash
+# macOS
+make transcribe URL="https://www.youtube.com/watch?v=VIDEO_ID" | pbcopy
+
+# Linux (xclip)
+make transcribe URL="https://www.youtube.com/watch?v=VIDEO_ID" | xclip -selection clipboard
+
+# Linux (xsel)
+make transcribe URL="https://www.youtube.com/watch?v=VIDEO_ID" | xsel --clipboard --input
+```
+
+### Save to File
+
+```bash
+# Save transcript
+make transcribe URL="https://www.youtube.com/watch?v=VIDEO_ID" > transcript.txt
+
+# Append to file
+make transcribe URL="..." >> all-transcripts.txt
+```
+
+### Suppress Progress Output
+
+```bash
+# Hide progress messages while piping
+make transcribe URL="..." 2>/dev/null | pbcopy
+```
+
+### Text Processing
+
+```bash
+# Word count
+make transcribe URL="..." 2>/dev/null | wc -w
+
+# Line count
+make transcribe URL="..." 2>/dev/null | wc -l
+
+# Search for keywords
+make transcribe URL="..." | grep -i "keyword"
+
+# Get first N lines
+make transcribe URL="..." | head -20
+```
+
+### Exit Codes
+
+- `0`: Success
+- `1`: Error (invalid URL, file not found, transcription failed, etc.)
+
+Check stderr for error details:
+```bash
+make transcribe URL="..." 2>&1 | head  # See error messages
+```
+
+---
+
 ## Webhooks (Coming Soon)
 
 Future versions will support webhook notifications for job completion:

--- a/docs/development.md
+++ b/docs/development.md
@@ -100,6 +100,43 @@ The CLI tool directly uses the `engine/` package (ADR-0001: Dual Consumption Mod
 - Scripting and automation
 - Debugging the transcription pipeline
 
+#### CLI Output and Piping
+
+The transcribe CLI outputs **only the transcript text to stdout** and **progress/diagnostics to stderr**. This enables composable Unix workflows:
+
+##### Copy transcript to clipboard (macOS)
+```bash
+make transcribe URL="https://www.youtube.com/watch?v=dQw4w9WgXcQ" | pbcopy
+```
+
+##### Save transcript to file
+```bash
+make transcribe URL="https://www.youtube.com/watch?v=dQw4w9WgXcQ" > transcript.txt
+make transcribe URL="https://www.instagram.com/reel/ABC123/" >> all-transcripts.txt
+```
+
+##### Suppress progress output
+```bash
+make transcribe URL="https://www.youtube.com/watch?v=dQw4w9WgXcQ" 2>/dev/null | pbcopy
+```
+
+##### Get transcript statistics
+```bash
+# Word count
+make transcribe URL="..." 2>/dev/null | wc -w
+
+# Line count
+make transcribe URL="..." 2>/dev/null | wc -l
+
+# Search for keywords
+make transcribe URL="..." | grep -i "important"
+
+# Get first 10 lines
+make transcribe URL="..." | head -10
+```
+
+**Why separate output streams?** Progress and transcription status appears on stderr, so you see what's happening while piping the clean transcript to other tools. This follows Unix conventions for composable commands.
+
 ### Development Server Options
 
 #### Option 1: Standard Go Server (Fiber)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -674,6 +674,92 @@ go tool pprof http://localhost:6060/debug/pprof/heap
 go tool pprof -http=:8080 profile.pb.gz
 ```
 
+## CLI and Output Issues
+
+### Clipboard Tool Not Found
+
+When using `make transcribe URL="..." | pbcopy` or clipboard piping, you may encounter clipboard tool errors.
+
+#### macOS
+- **pbcopy** is built-in to macOS
+- If missing, reinstall Command Line Tools:
+  ```bash
+  xcode-select --install
+  ```
+
+#### Linux - xclip (Recommended)
+```bash
+# Debian/Ubuntu
+sudo apt update && sudo apt install xclip
+
+# Fedora/RHEL
+sudo dnf install xclip
+
+# Arch
+sudo pacman -S xclip
+
+# Then use:
+make transcribe URL="..." | xclip -selection clipboard
+```
+
+#### Linux - xsel (Fallback)
+```bash
+# Debian/Ubuntu
+sudo apt install xsel
+
+# Fedora/RHEL
+sudo dnf install xsel
+
+# Arch
+sudo pacman -S xsel
+
+# Then use:
+make transcribe URL="..." | xsel --clipboard --input
+```
+
+#### Windows (WSL - Windows Subsystem for Linux)
+```bash
+# Use Windows clip.exe instead of pbcopy
+make transcribe URL="..." | clip.exe
+```
+
+#### No Clipboard Tool Available
+If no clipboard tool is installed and you can't install one:
+```bash
+# Save to file instead
+make transcribe URL="..." > transcript.txt
+
+# Or use Python if available
+make transcribe URL="..." | python3 -c "import sys; print(sys.stdin.read())"
+```
+
+### Transcript Not Appearing on Clipboard
+
+**Problem:** Running `make transcribe URL="..." | pbcopy` but transcript doesn't appear in clipboard.
+
+**Solution:** Verify the command is working correctly:
+```bash
+# Test without pbcopy - see transcript on screen
+make transcribe URL="..." 2>/dev/null
+
+# Check that pbcopy command works
+echo "test" | pbcopy && pbpaste  # Should output "test"
+
+# Check that pipe is working
+make transcribe URL="..." 2>/dev/null | wc -w  # Should show word count
+```
+
+### Too Much Output When Copying to Clipboard
+
+**Problem:** Clipboard contains progress messages along with transcript.
+
+**Solution:** Redirect stderr to /dev/null:
+```bash
+make transcribe URL="..." 2>/dev/null | pbcopy
+```
+
+This suppresses progress/diagnostic output on stderr and only copies the transcript to clipboard.
+
 ## Getting Help
 
 ### Log Analysis

--- a/examples/transcribe/main.go
+++ b/examples/transcribe/main.go
@@ -34,18 +34,19 @@ func main() {
 	if !isURL {
 		// Check if local file exists
 		if _, err := os.Stat(input); os.IsNotExist(err) {
-			fmt.Printf("Error: File not found: %s\n", input)
+			fmt.Fprintf(os.Stderr, "Error: File not found: %s\n", input)
 			os.Exit(1)
 		}
 	}
 
-	fmt.Printf("Transcribing: %s\n", input)
+	// Print progress to stderr (not part of transcript output)
+	fmt.Fprintf(os.Stderr, "Transcribing: %s\n", input)
 	if isURL {
-		fmt.Println("Type: URL (downloading via yt-dlp)")
+		fmt.Fprintf(os.Stderr, "Type: URL (downloading via yt-dlp)\n")
 	} else {
-		fmt.Println("Type: Local file")
+		fmt.Fprintf(os.Stderr, "Type: Local file\n")
 	}
-	fmt.Println()
+	fmt.Fprintf(os.Stderr, "\n")
 
 	// Create a context with timeout for the transcription
 	// ADR-0003: Context propagation with appropriate timeouts
@@ -61,53 +62,42 @@ func main() {
 	opts.CacheDownloads = true // Cache downloads for CLI usage
 	result, err := engine.Transcribe(ctx, input, "cli-transcribe", opts)
 	if err != nil {
-		// Provide stage-specific error context
+		// Provide stage-specific error context to stderr
 		if tErr, ok := err.(*engine.TranscriptionError); ok {
-			fmt.Printf("Transcription failed at stage '%s': %s\n", tErr.Stage, tErr.Message)
+			fmt.Fprintf(os.Stderr, "Transcription failed at stage '%s': %s\n", tErr.Stage, tErr.Message)
 			if tErr.Err != nil {
-				fmt.Printf("  Cause: %v\n", tErr.Err)
+				fmt.Fprintf(os.Stderr, "  Cause: %v\n", tErr.Err)
 			}
 		} else {
-			fmt.Printf("Transcription failed: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Transcription failed: %v\n", err)
 		}
 		os.Exit(1)
 	}
 
 	elapsed := time.Since(startTime)
 
-	// Print the transcript
-	fmt.Println("--- Transcript ---")
-	fmt.Println(result.Transcript)
-	fmt.Println()
+	// Output ONLY transcript to stdout (clean for piping)
+	fmt.Fprint(os.Stdout, result.Transcript)
 
-	// Print segments with timestamps
-	if len(result.Segments) > 0 {
-		fmt.Println("--- Segments ---")
-		for _, seg := range result.Segments {
-			fmt.Printf("[%0.1fs - %0.1fs] %s\n", seg.Start, seg.End, seg.Text)
-		}
-		fmt.Println()
-	}
-
-	// Print summary
-	fmt.Println("--- Summary ---")
-	fmt.Printf("Duration: %s\n", elapsed.Round(time.Second))
-	fmt.Printf("Segments: %d\n", len(result.Segments))
+	// Print diagnostic information to stderr
+	fmt.Fprintf(os.Stderr, "\n--- Summary ---\n")
+	fmt.Fprintf(os.Stderr, "Duration: %s\n", elapsed.Round(time.Second))
+	fmt.Fprintf(os.Stderr, "Segments: %d\n", len(result.Segments))
 }
 
 func printUsage() {
-	fmt.Println("Usage: go run main.go <url_or_file_path>")
-	fmt.Println()
-	fmt.Println("Examples:")
-	fmt.Println("  # Transcribe a YouTube video")
-	fmt.Println("  go run main.go https://www.youtube.com/watch?v=dQw4w9WgXcQ")
-	fmt.Println()
-	fmt.Println("  # Transcribe an Instagram reel")
-	fmt.Println("  go run main.go https://www.instagram.com/reel/ABC123/")
-	fmt.Println()
-	fmt.Println("  # Transcribe a local file")
-	fmt.Println("  go run main.go /path/to/video.mp4")
-	fmt.Println()
-	fmt.Println("Or use the Makefile:")
-	fmt.Println("  make transcribe URL=\"https://youtube.com/watch?v=...\"")
+	fmt.Fprintf(os.Stderr, "Usage: go run main.go <url_or_file_path>\n")
+	fmt.Fprintf(os.Stderr, "\n")
+	fmt.Fprintf(os.Stderr, "Examples:\n")
+	fmt.Fprintf(os.Stderr, "  # Transcribe a YouTube video\n")
+	fmt.Fprintf(os.Stderr, "  go run main.go https://www.youtube.com/watch?v=dQw4w9WgXcQ\n")
+	fmt.Fprintf(os.Stderr, "\n")
+	fmt.Fprintf(os.Stderr, "  # Transcribe an Instagram reel\n")
+	fmt.Fprintf(os.Stderr, "  go run main.go https://www.instagram.com/reel/ABC123/\n")
+	fmt.Fprintf(os.Stderr, "\n")
+	fmt.Fprintf(os.Stderr, "  # Transcribe a local file\n")
+	fmt.Fprintf(os.Stderr, "  go run main.go /path/to/video.mp4\n")
+	fmt.Fprintf(os.Stderr, "\n")
+	fmt.Fprintf(os.Stderr, "Or use the Makefile:\n")
+	fmt.Fprintf(os.Stderr, "  make transcribe URL=\"https://youtube.com/watch?v=...\"\n")
 }

--- a/makefile
+++ b/makefile
@@ -82,16 +82,16 @@ endif
 .PHONY: transcribe
 transcribe: ## Transcribe a URL or file (make transcribe URL="https://...")
 ifndef URL
-	@echo "$(RED)Error: URL is required$(NC)"
-	@echo "Usage: make transcribe URL=\"https://youtube.com/watch?v=...\""
-	@echo ""
-	@echo "Examples:"
-	@echo "  make transcribe URL=\"https://www.youtube.com/watch?v=dQw4w9WgXcQ\""
-	@echo "  make transcribe URL=\"https://www.instagram.com/reel/ABC123/\""
-	@echo "  make transcribe URL=\"/path/to/video.mp4\""
+	@echo "$(RED)Error: URL is required$(NC)" >&2
+	@echo "Usage: make transcribe URL=\"https://youtube.com/watch?v=...\"" >&2
+	@echo "" >&2
+	@echo "Examples:" >&2
+	@echo "  make transcribe URL=\"https://www.youtube.com/watch?v=dQw4w9WgXcQ\"" >&2
+	@echo "  make transcribe URL=\"https://www.instagram.com/reel/ABC123/\"" >&2
+	@echo "  make transcribe URL=\"/path/to/video.mp4\"" >&2
 	@exit 1
 endif
-	@echo "$(BLUE)Transcribing: $(URL)$(NC)"
+	@echo "$(BLUE)Transcribing: $(URL)$(NC)" >&2
 	@mkdir -p $(BUILD_DIR)
 	@CGO_ENABLED=1 go build -o $(BUILD_DIR)/transcribe examples/transcribe/main.go
 	@WHISPER_MODEL_PATH=models/ggml-base.en.bin $(BUILD_DIR)/transcribe "$(URL)"

--- a/readme.md
+++ b/readme.md
@@ -131,6 +131,27 @@ curl -L https://encore.dev/install.sh | bash
 encore deploy --env production
 ```
 
+### Command-Line Interface (CLI)
+
+For quick one-off transcriptions without starting a server:
+
+```bash
+# Copy transcript to clipboard (macOS)
+make transcribe URL="https://www.youtube.com/watch?v=..." | pbcopy
+
+# Save transcript to file
+make transcribe URL="https://www.youtube.com/watch?v=..." > transcript.txt
+
+# Get transcript statistics
+make transcribe URL="..." 2>/dev/null | wc -w  # Word count
+```
+
+The CLI is perfect for:
+- Quick transcriptions without server overhead
+- Automation and scripting
+- Integration with Unix pipelines
+- CI/CD workflows
+
 ## Usage
 
 ### As a Go Library


### PR DESCRIPTION
## Summary

- make the transcribe CLI emit only transcript data on stdout while routing progress, usage, errors, and summary details to stderr
- keep the Makefile wrapper on the same stream contract so clipboard, file, and text-processing pipelines remain clean
- document clipboard and Unix pipeline workflows across the README, API, development, and troubleshooting guides
- archive the completed branch plan and record the stream contract in ADR 0005

## Verification

- `env GOCACHE=/tmp/omnitranscripts-go-cache CGO_ENABLED=0 go test -short ./...`
- `env GOCACHE=/tmp/omnitranscripts-go-cache CGO_ENABLED=0 go vet ./...`
- `env GOCACHE=/tmp/omnitranscripts-go-cache CGO_ENABLED=0 go build ./...`
- `env GOCACHE=/tmp/omnitranscripts-go-cache CGO_ENABLED=1 go build -o /tmp/omnitranscripts-transcribe examples/transcribe/main.go`
- `make transcribe` missing-input smoke test: exit 2, 0 stdout bytes, diagnostics on stderr
- `git diff --check origin/main...HEAD`

## Architecture and versioning

- ADR: `doc/decisions/0005-separate-cli-data-and-diagnostic-streams.md`
- Version bump: not applicable; this repository has no standalone product version source

## Known limitations

- A live media transcription was not run because it requires the external model and media-tool runtime; the CGO CLI itself builds successfully.
