### PR TITLE
Harden dashboard input boundaries

### DIFF
--- a/.plan/.done/fix-security-dashboard-input-hardening/plan.md
+++ b/.plan/.done/fix-security-dashboard-input-hardening/plan.md
@@ -1,8 +1,8 @@
 # Harden Dashboard Identifiers and Subprocess Inputs
 
-**Backlog:** 2  
-**Branch:** `fix/security-dashboard-input-hardening`  
-**Status:** Completed  
+**Backlog:** 2
+**Branch:** `fix/security-dashboard-input-hardening`
+**Status:** Completed
 **Started:** 2026-08-09T22:30:08Z
 
 ## Reconciliation

--- a/.plan/backlog.json
+++ b/.plan/backlog.json
@@ -94,15 +94,20 @@
     },
     {
       "id": 2,
-      "title": "Fix Command Injection Risk in web-dashboard.go",
-      "description": "User-controlled input (job.VideoID, url) is passed directly to exec.Command() without proper sanitization. The pgrep -f command and yt-dlp command in web-dashboard.go:3297 and web-dashboard.go:3507 could be vulnerable to command injection if VideoID or URL contains shell metacharacters. Remediation: Validate and sanitize VideoID to ensure it only contains expected characters (alphanumeric, hyphens). URL validation should be strengthened.",
+      "title": "Harden Dashboard Identifiers and Subprocess Inputs",
+      "description": "The dashboard accepts an unvalidated media URL, derives a fallback VideoID, interpolates persisted VideoID values into transcript filesystem paths and a pgrep regular expression, and passes the URL to yt-dlp. exec.Command does not invoke a shell, so the original command-injection wording is imprecise; the actionable risks are path traversal from untrusted persisted identifiers, regex/process-match manipulation, unsafe URL schemes, and collisions for non-YouTube sources. Validate HTTP(S) media URLs, derive bounded safe identifiers, reject unsafe persisted identifiers before filesystem use, quote dynamic regex text, and terminate yt-dlp option parsing before the URL.",
       "category": "security",
       "severity": "high",
       "fingerprint": "SEC-INJ-001",
       "source": "/pro:audit",
-      "sourceBranch": "main",
+      "sourceBranch": "fix/security-dashboard-input-hardening",
       "createdAt": "2026-01-10T09:43:37Z",
-      "status": "pending"
+      "status": "completed",
+      "startedAt": "2026-08-09T22:30:08Z",
+      "completedAt": "2026-08-09T22:33:49Z",
+      "completionEvidence": "Added tested HTTP(S) URL validation, deterministic safe media identifiers, guarded path construction, validated persisted identifiers, quoted process patterns, derived log paths, and yt-dlp option termination. Targeted tests, vet, repository build, explicit dashboard build/vet, backlog validation, and diff checks pass.",
+      "phase": "must",
+      "mvpBatch": "commercial-api-readiness-v1"
     },
     {
       "id": 3,

--- a/.plan/fix-security-dashboard-input-hardening/plan.md
+++ b/.plan/fix-security-dashboard-input-hardening/plan.md
@@ -1,0 +1,55 @@
+# Harden Dashboard Identifiers and Subprocess Inputs
+
+**Backlog:** 2  
+**Branch:** `fix/security-dashboard-input-hardening`  
+**Status:** Completed  
+**Started:** 2026-08-09T22:30:08Z
+
+## Reconciliation
+
+The original audit finding called this command injection. The dashboard uses `exec.Command` directly, not a shell, so shell metacharacters are not evaluated. The remaining security issue is valid: media URLs are unvalidated, persisted video identifiers reach filesystem paths and a regular expression, non-YouTube URLs collapse to `unknown`, and subprocess option parsing is not explicitly terminated.
+
+No existing ADR governs this input boundary. The change is defensive validation without a new architectural decision.
+
+## Requirements
+
+- Accept only absolute HTTP(S) media URLs with a hostname and no embedded credentials.
+- Preserve valid YouTube IDs; derive a deterministic, collision-resistant, identifier-safe value for other URLs.
+- Bound identifiers to ASCII letters, digits, `_`, and `-` before filesystem or process-pattern use.
+- Reject unsafe identifiers loaded from persisted job data rather than normalizing them into a different path.
+- Quote identifiers embedded in the `pgrep` regular expression.
+- Pass `--` before the media URL supplied to `yt-dlp`.
+- Return a stable `400` response for invalid URL submissions.
+
+## Implementation
+
+1. Add focused validation/identifier helpers in a normal internal package so the ignored dashboard entrypoint remains testable.
+2. Apply URL validation and safe identifier derivation in job creation.
+3. Guard transcript directory access during status and metric updates.
+4. Quote process-match input and terminate downloader option parsing.
+5. Add table-driven tests for URL schemes, credentials, YouTube extraction, deterministic fallback IDs, path traversal, length bounds, and regex metacharacters.
+
+## Verification
+
+- [x] `go test ./internal/dashboardsecurity -count=1`
+- [x] `go vet ./internal/dashboardsecurity`
+- [x] `go build ./...`
+- [x] `go vet ./...`
+- [x] `go build -o /tmp/omnitranscripts-web-dashboard web-dashboard.go`
+- [x] `go vet web-dashboard.go`
+- [x] Backlog structural validation and `git diff --check`
+
+The full suite is intentionally deferred to backlog item 4, which already records the reproducible hanging-test condition and is dependency-ordered after duration parsing.
+
+## Result
+
+- Invalid, relative, credential-bearing, and non-HTTP(S) URLs return `400` before job persistence or subprocess use.
+- YouTube watch, short, Shorts, embed, and live URLs retain their native 11-character ID.
+- Other providers receive a deterministic SHA-256-derived identifier instead of sharing `unknown`.
+- Persisted identifiers are rejected before transcript or log filesystem access.
+- Dynamic process matching is regular-expression quoted and downloader option parsing ends before the URL.
+
+## Risks
+
+- Existing persisted jobs with unsafe identifiers will no longer have their transcript directories inspected; they remain visible but cannot trigger filesystem traversal.
+- Deterministic IDs for non-YouTube sources change new dashboard output directory names from the shared `unknown` directory.

--- a/internal/dashboardsecurity/input.go
+++ b/internal/dashboardsecurity/input.go
@@ -1,0 +1,138 @@
+package dashboardsecurity
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/url"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+const maxIdentifierLength = 128
+
+var (
+	identifierPattern = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+	youtubeIDPattern  = regexp.MustCompile(`^[A-Za-z0-9_-]{11}$`)
+)
+
+// ParseMediaURL validates an externally supplied media URL before it reaches a
+// downloader subprocess. Only absolute HTTP(S) URLs without embedded
+// credentials are accepted.
+func ParseMediaURL(raw string) (*url.URL, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, errors.New("media URL is required")
+	}
+
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return nil, fmt.Errorf("parse media URL: %w", err)
+	}
+
+	if !strings.EqualFold(parsed.Scheme, "http") && !strings.EqualFold(parsed.Scheme, "https") {
+		return nil, errors.New("media URL must use http or https")
+	}
+	if parsed.Hostname() == "" {
+		return nil, errors.New("media URL must include a hostname")
+	}
+	if parsed.User != nil {
+		return nil, errors.New("media URL must not contain credentials")
+	}
+
+	parsed.Scheme = strings.ToLower(parsed.Scheme)
+	parsed.Host = strings.ToLower(parsed.Host)
+	return parsed, nil
+}
+
+// MediaID returns the native YouTube ID when one is available. Other sources
+// receive a deterministic hash-derived identifier instead of sharing an
+// "unknown" directory.
+func MediaID(mediaURL *url.URL) string {
+	if id := youtubeID(mediaURL); id != "" {
+		return id
+	}
+
+	sum := sha256.Sum256([]byte(mediaURL.String()))
+	return "media_" + hex.EncodeToString(sum[:12])
+}
+
+// ValidateIdentifier rejects persisted identifiers before they are used in a
+// filesystem path, response filename, or process-match expression.
+func ValidateIdentifier(identifier string) error {
+	if identifier == "" {
+		return errors.New("identifier is required")
+	}
+	if len(identifier) > maxIdentifierLength {
+		return fmt.Errorf("identifier exceeds %d characters", maxIdentifierLength)
+	}
+	if !identifierPattern.MatchString(identifier) {
+		return errors.New("identifier contains unsupported characters")
+	}
+	return nil
+}
+
+// Directory joins a trusted root to a validated identifier.
+func Directory(root, identifier string) (string, error) {
+	if root == "" {
+		return "", errors.New("directory root is required")
+	}
+	if err := ValidateIdentifier(identifier); err != nil {
+		return "", err
+	}
+	return filepath.Join(root, identifier), nil
+}
+
+// File joins a trusted root to a validated identifier and trusted suffix.
+func File(root, identifier, suffix string) (string, error) {
+	if root == "" {
+		return "", errors.New("file root is required")
+	}
+	if err := ValidateIdentifier(identifier); err != nil {
+		return "", err
+	}
+	return filepath.Join(root, identifier+suffix), nil
+}
+
+// ProcessPattern quotes dynamic text even though accepted identifiers cannot
+// currently contain regular-expression metacharacters. This keeps the safety
+// property explicit if the identifier grammar changes later.
+func ProcessPattern(identifier string) (string, error) {
+	if err := ValidateIdentifier(identifier); err != nil {
+		return "", err
+	}
+	return `transcribe.*` + regexp.QuoteMeta(identifier), nil
+}
+
+func youtubeID(mediaURL *url.URL) string {
+	host := strings.TrimSuffix(strings.ToLower(mediaURL.Hostname()), ".")
+	var candidate string
+
+	switch host {
+	case "youtu.be":
+		candidate = firstPathSegment(mediaURL.Path)
+	case "youtube.com", "www.youtube.com", "m.youtube.com", "music.youtube.com":
+		candidate = mediaURL.Query().Get("v")
+		if candidate == "" {
+			segments := strings.Split(strings.Trim(mediaURL.Path, "/"), "/")
+			if len(segments) >= 2 && (segments[0] == "embed" || segments[0] == "shorts" || segments[0] == "live") {
+				candidate = segments[1]
+			}
+		}
+	}
+
+	if youtubeIDPattern.MatchString(candidate) {
+		return candidate
+	}
+	return ""
+}
+
+func firstPathSegment(path string) string {
+	segments := strings.Split(strings.Trim(path, "/"), "/")
+	if len(segments) == 0 {
+		return ""
+	}
+	return segments[0]
+}

--- a/internal/dashboardsecurity/input_test.go
+++ b/internal/dashboardsecurity/input_test.go
@@ -1,0 +1,124 @@
+package dashboardsecurity
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestParseMediaURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		wantErr bool
+	}{
+		{name: "https", raw: "https://example.com/media.mp3"},
+		{name: "http", raw: "http://example.com/video.mp4"},
+		{name: "trim whitespace", raw: "  https://example.com/media.mp3  "},
+		{name: "missing", raw: "", wantErr: true},
+		{name: "relative", raw: "/media.mp3", wantErr: true},
+		{name: "file scheme", raw: "file:///etc/passwd", wantErr: true},
+		{name: "ftp scheme", raw: "ftp://example.com/media.mp3", wantErr: true},
+		{name: "missing hostname", raw: "https:///media.mp3", wantErr: true},
+		{name: "embedded credentials", raw: "https://user:pass@example.com/media.mp3", wantErr: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := ParseMediaURL(test.raw)
+			if (err != nil) != test.wantErr {
+				t.Fatalf("ParseMediaURL(%q) error = %v, wantErr %v", test.raw, err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestMediaID(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{name: "watch", raw: "https://www.youtube.com/watch?v=dQw4w9WgXcQ", want: "dQw4w9WgXcQ"},
+		{name: "short URL", raw: "https://youtu.be/dQw4w9WgXcQ", want: "dQw4w9WgXcQ"},
+		{name: "shorts", raw: "https://youtube.com/shorts/dQw4w9WgXcQ", want: "dQw4w9WgXcQ"},
+		{name: "embed", raw: "https://youtube.com/embed/dQw4w9WgXcQ", want: "dQw4w9WgXcQ"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			parsed, err := ParseMediaURL(test.raw)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := MediaID(parsed); got != test.want {
+				t.Fatalf("MediaID(%q) = %q, want %q", test.raw, got, test.want)
+			}
+		})
+	}
+
+	first, err := ParseMediaURL("https://example.com/media.mp3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := ParseMediaURL("https://example.com/other.mp3")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	firstID := MediaID(first)
+	if firstID != MediaID(first) {
+		t.Fatal("fallback media ID is not deterministic")
+	}
+	if firstID == MediaID(second) {
+		t.Fatal("different URLs produced the same fallback media ID")
+	}
+	if !strings.HasPrefix(firstID, "media_") {
+		t.Fatalf("fallback media ID %q lacks media_ prefix", firstID)
+	}
+	if err := ValidateIdentifier(firstID); err != nil {
+		t.Fatalf("fallback media ID is unsafe: %v", err)
+	}
+}
+
+func TestValidateIdentifier(t *testing.T) {
+	valid := []string{"dQw4w9WgXcQ", "job_123", "media_deadbeef"}
+	for _, identifier := range valid {
+		if err := ValidateIdentifier(identifier); err != nil {
+			t.Errorf("ValidateIdentifier(%q) returned %v", identifier, err)
+		}
+	}
+
+	invalid := []string{"", "../outside", "nested/path", "line\nbreak", "regex.*", strings.Repeat("a", 129)}
+	for _, identifier := range invalid {
+		if err := ValidateIdentifier(identifier); err == nil {
+			t.Errorf("ValidateIdentifier(%q) succeeded", identifier)
+		}
+	}
+}
+
+func TestSafePathsAndProcessPattern(t *testing.T) {
+	dir, err := Directory("transcripts", "safe-id")
+	if err != nil || dir != "transcripts/safe-id" {
+		t.Fatalf("Directory() = %q, %v", dir, err)
+	}
+	if _, err := Directory("transcripts", "../outside"); err == nil {
+		t.Fatal("Directory accepted traversal identifier")
+	}
+
+	file, err := File("logs", "job_123", ".log")
+	if err != nil || file != "logs/job_123.log" {
+		t.Fatalf("File() = %q, %v", file, err)
+	}
+
+	pattern, err := ProcessPattern("safe-id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !regexp.MustCompile(pattern).MatchString("transcribe --job safe-id") {
+		t.Fatalf("pattern %q did not match expected process", pattern)
+	}
+	if _, err := ProcessPattern("unsafe.*"); err == nil {
+		t.Fatal("ProcessPattern accepted regex metacharacters")
+	}
+}

--- a/web-dashboard.go
+++ b/web-dashboard.go
@@ -11,11 +11,14 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+
+	"omnitranscripts/internal/dashboardsecurity"
 )
 
 var startTime = time.Now()
@@ -2742,10 +2745,13 @@ func calculatePerformanceMetrics(data *DashboardData, jobs []Job) {
 	var totalStorage int64
 	for _, job := range jobs {
 		if job.Status == "completed" {
-			outputDir := fmt.Sprintf("transcripts/%s", job.VideoID)
+			outputDir, err := dashboardsecurity.Directory("transcripts", job.VideoID)
+			if err != nil {
+				continue
+			}
 			if files, err := os.ReadDir(outputDir); err == nil {
 				for _, file := range files {
-					if fileStat, err := os.Stat(fmt.Sprintf("%s/%s", outputDir, file.Name())); err == nil {
+					if fileStat, err := os.Stat(filepath.Join(outputDir, file.Name())); err == nil {
 						totalStorage += fileStat.Size()
 					}
 				}
@@ -2846,20 +2852,31 @@ func addJobHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	videoID := extractVideoID(req.URL)
+	mediaURL, err := dashboardsecurity.ParseMediaURL(req.URL)
+	if err != nil {
+		http.Error(w, "Invalid media URL: use an absolute HTTP(S) URL without embedded credentials", http.StatusBadRequest)
+		return
+	}
+
+	videoID := dashboardsecurity.MediaID(mediaURL)
+	outputDir, err := dashboardsecurity.Directory("transcripts", videoID)
+	if err != nil {
+		http.Error(w, "Invalid media identifier", http.StatusBadRequest)
+		return
+	}
 	jobID := generateJobID()
 
 	job := Job{
 		ID:            jobID,
 		VideoID:       videoID,
-		URL:           req.URL,
+		URL:           mediaURL.String(),
 		Title:         "Loading...",
 		Status:        "queued",
 		Progress:      0,
 		StartTime:     time.Now(),
 		UpdateTime:    time.Now(),
 		LogFile:       fmt.Sprintf("logs/%s.log", jobID),
-		OutputDir:     fmt.Sprintf("transcripts/%s", videoID),
+		OutputDir:     outputDir,
 		Duration:      "00:00",
 		FileCount:     0,
 		FileSize:      "0 KB",
@@ -2987,6 +3004,10 @@ func downloadHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "No transcript available for this job", 404)
 		return
 	}
+	if err := dashboardsecurity.ValidateIdentifier(job.VideoID); err != nil {
+		http.Error(w, "Invalid stored media identifier", http.StatusInternalServerError)
+		return
+	}
 
 	// Generate content based on format
 	var content string
@@ -3109,8 +3130,15 @@ func logsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Try to read the log file
-	content, err := os.ReadFile(job.LogFile)
+	logPath, err := dashboardsecurity.File("logs", job.ID, ".log")
+	if err != nil {
+		http.Error(w, "Invalid stored job identifier", http.StatusInternalServerError)
+		return
+	}
+
+	// Derive the log path from the validated job ID instead of trusting the
+	// persisted LogFile field.
+	content, err := os.ReadFile(logPath)
 	if err != nil {
 		http.Error(w, "Log file not found or could not be read", 404)
 		return
@@ -3118,7 +3146,7 @@ func logsHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Set headers
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-	w.Header().Set("Content-Disposition", fmt.Sprintf("inline; filename=\"%s_log.txt\"", job.VideoID))
+	w.Header().Set("Content-Disposition", fmt.Sprintf("inline; filename=\"%s.log.txt\"", job.ID))
 
 	// Write content
 	w.Write(content)
@@ -3272,8 +3300,14 @@ func updateJobStatuses(jobs []Job) {
 }
 
 func updateJobStatus(job *Job) {
+	outputDir, err := dashboardsecurity.Directory("transcripts", job.VideoID)
+	if err != nil {
+		markInvalidIdentifier(job)
+		return
+	}
+
 	// Load metadata if available
-	metadataPath := fmt.Sprintf("transcripts/%s/metadata.json", job.VideoID)
+	metadataPath := filepath.Join(outputDir, "metadata.json")
 	if metadataData, err := os.ReadFile(metadataPath); err == nil {
 		var metadata map[string]interface{}
 		if json.Unmarshal(metadataData, &metadata) == nil {
@@ -3288,13 +3322,25 @@ func updateJobStatus(job *Job) {
 
 	// If title is still "Loading...", try to fetch it directly with yt-dlp
 	if job.Title == "Loading..." && job.URL != "" {
-		if title := fetchVideoTitle(job.URL); title != "" {
+		mediaURL, err := dashboardsecurity.ParseMediaURL(job.URL)
+		if err != nil {
+			job.Status = "failed"
+			job.StatusText = "Invalid media URL"
+			job.UpdateTime = time.Now()
+			return
+		}
+		if title := fetchVideoTitle(mediaURL.String()); title != "" {
 			job.Title = title
 		}
 	}
 
 	// Check if transcription process is running
-	cmd := exec.Command("pgrep", "-f", fmt.Sprintf("transcribe.*%s", job.VideoID))
+	processPattern, err := dashboardsecurity.ProcessPattern(job.VideoID)
+	if err != nil {
+		markInvalidIdentifier(job)
+		return
+	}
+	cmd := exec.Command("pgrep", "-f", processPattern)
 	if output, err := cmd.Output(); err == nil && len(strings.TrimSpace(string(output))) > 0 {
 		status, progress := parseJobProgress(job)
 		job.Status = status
@@ -3306,7 +3352,6 @@ func updateJobStatus(job *Job) {
 	}
 
 	// Check if completed
-	outputDir := fmt.Sprintf("transcripts/%s", job.VideoID)
 	if files, err := os.ReadDir(outputDir); err == nil && len(files) > 0 {
 		if job.Status != "completed" {
 			// Only update status and stats if not already completed
@@ -3356,14 +3401,17 @@ func updateJobStats(job *Job) {
 	}
 
 	// Calculate file size
-	outputDir := fmt.Sprintf("transcripts/%s", job.VideoID)
+	outputDir, err := dashboardsecurity.Directory("transcripts", job.VideoID)
+	if err != nil {
+		return
+	}
 	if stat, err := os.Stat(outputDir); err == nil && stat.IsDir() {
 		var totalSize int64
 		files, _ := os.ReadDir(outputDir)
 		job.FileCount = len(files)
 
 		for _, file := range files {
-			if fileStat, err := os.Stat(fmt.Sprintf("%s/%s", outputDir, file.Name())); err == nil {
+			if fileStat, err := os.Stat(filepath.Join(outputDir, file.Name())); err == nil {
 				totalSize += fileStat.Size()
 			}
 		}
@@ -3373,9 +3421,11 @@ func updateJobStats(job *Job) {
 
 func parseJobProgress(job *Job) (string, int) {
 	logFiles := []string{
-		job.LogFile,
 		"transcription.log",
 		"nohup.out",
+	}
+	if jobLog, err := dashboardsecurity.File("logs", job.ID, ".log"); err == nil {
+		logFiles = append([]string{jobLog}, logFiles...)
 	}
 
 	for _, logFile := range logFiles {
@@ -3433,15 +3483,6 @@ func extractTitleFromLog(filename string) string {
 		}
 	}
 	return ""
-}
-
-func extractVideoID(url string) string {
-	re := regexp.MustCompile(`(?:youtube\.com/watch\?v=|youtu\.be/|youtube\.com/embed/)([a-zA-Z0-9_-]{11})`)
-	matches := re.FindStringSubmatch(url)
-	if len(matches) >= 2 {
-		return matches[1]
-	}
-	return "unknown"
 }
 
 func generateJobID() string {
@@ -3504,12 +3545,18 @@ func calculateBusinessMetrics(data *DashboardData, jobs []Job) {
 // fetchVideoTitle fetches the video title using yt-dlp
 func fetchVideoTitle(url string) string {
 	// Use yt-dlp to get just the title
-	cmd := exec.Command("yt-dlp", "--get-title", "--no-warnings", url)
+	cmd := exec.Command("yt-dlp", "--get-title", "--no-warnings", "--", url)
 	output, err := cmd.Output()
 	if err != nil {
 		return ""
 	}
 	return strings.TrimSpace(string(output))
+}
+
+func markInvalidIdentifier(job *Job) {
+	job.Status = "failed"
+	job.StatusText = "Invalid media identifier"
+	job.UpdateTime = time.Now()
 }
 
 // reloadCheckHandler returns file modification timestamp for live reload


### PR DESCRIPTION
## Summary

- validate dashboard media inputs as absolute HTTP(S) URLs without embedded credentials
- preserve valid YouTube IDs and derive deterministic, identifier-safe IDs for other providers
- reject unsafe persisted identifiers before filesystem and process-pattern use
- derive trusted transcript/log paths, quote process matching, and terminate `yt-dlp` option parsing
- add focused tests for URL validation, identifier derivation, traversal prevention, and process patterns

## Verification

- `GOCACHE=/tmp/omnitranscripts-go-cache go test ./internal/dashboardsecurity -count=1`
- `GOCACHE=/tmp/omnitranscripts-go-cache go vet ./internal/dashboardsecurity`
- `GOCACHE=/tmp/omnitranscripts-go-cache go build ./...`
- `GOCACHE=/tmp/omnitranscripts-go-cache go vet ./...`
- `GOCACHE=/tmp/omnitranscripts-go-cache go build -o /tmp/omnitranscripts-web-dashboard web-dashboard.go`
- `GOCACHE=/tmp/omnitranscripts-go-cache go vet web-dashboard.go`
- `GOCACHE=/tmp/omnitranscripts-go-cache go test -short -timeout=60s ./...`
- `gofmt -d internal/dashboardsecurity/input.go internal/dashboardsecurity/input_test.go web-dashboard.go`
- `jq empty .plan/backlog.json`
- `git diff --check main...HEAD`

## Architecture and versioning

- ADR: none; this is defensive validation at an existing input boundary and introduces no architectural decision
- Version: no bump; the repository has no primary semantic version source and builds identify themselves from Git commit metadata

## Known limitations

- The non-short full test suite remains deferred to the existing test-stabilization backlog item because the repository records a reproducible hanging-test condition. The short full-package suite passes under an explicit timeout.
- Existing persisted jobs with unsafe identifiers remain visible, but their transcript directories and logs are no longer read.
- New non-YouTube jobs use deterministic hashed directory IDs instead of the previous shared `unknown` directory.
